### PR TITLE
fixed pty.js build error on all new OSX systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dependencies": {
         "express": "3.4.4",
         "socket.io": "1.1.0",
-        "pty.js": "0.2.4",
+        "pty.js": "soumith/pty.js",
         "recursive-readdir": "0.0.2"
     },
     "optionalDependencies" : {


### PR DESCRIPTION
Better late than never! Fixed #17 for all users without them having to manually download/clone pty and install it.
